### PR TITLE
Add Cognigy deployment workflow

### DIFF
--- a/.github/cognigy-deployments.yml
+++ b/.github/cognigy-deployments.yml
@@ -1,0 +1,20 @@
+# Cognigy Extension Deployment Configuration
+#
+# This file defines which Cognigy projects should receive automatic extension deployments
+# when releases are created.
+#
+# Required GitHub Secrets per environment:
+#   COGNIGY_{ENVIRONMENT}_API_KEY  - API key for authentication
+#   COGNIGY_{ENVIRONMENT}_URL      - Base URL (e.g., https://api-trial.cognigy.ai)
+#
+# GitHub Environment Variables (optional):
+#   COGNIGY_FAIL_FAST - Set to 'true' to fail workflow on first deployment error
+#                     - Set to 'false' to continue and report all failures at end
+#                     - Default: false
+
+deployments:
+  - name: "Ben Elliot - APK"
+    environment: "CSA_INT"
+    projectId: "68cc9c59ae744c215e32ef67"
+    releaseTypes: ["major", "minor", "patch"]
+    enabled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
@@ -72,3 +73,185 @@ jobs:
         run: |
           echo "Tag v${{ steps.version.outputs.version }} already exists. Skipping release creation."
           echo "If you need to create a new release, bump the version in package.json."
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: release
+    if: always() && needs.release.result == 'success'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Get version and determine release type
+        id: version_info
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Parse current version
+          if [[ $CURRENT_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            CURRENT_MAJOR="${BASH_REMATCH[1]}"
+            CURRENT_MINOR="${BASH_REMATCH[2]}"
+            CURRENT_PATCH="${BASH_REMATCH[3]}"
+          else
+            echo "❌ Invalid current version format: $CURRENT_VERSION"
+            exit 1
+          fi
+
+          # Get previous release tag
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || echo "")
+
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            # First release - assume major
+            RELEASE_TYPE="major"
+            echo "📦 First release detected: v$CURRENT_VERSION (Type: $RELEASE_TYPE)"
+          else
+            # Parse previous version
+            PREVIOUS_VERSION="${PREVIOUS_TAG#v}"
+
+            if [[ $PREVIOUS_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              PREVIOUS_MAJOR="${BASH_REMATCH[1]}"
+              PREVIOUS_MINOR="${BASH_REMATCH[2]}"
+              PREVIOUS_PATCH="${BASH_REMATCH[3]}"
+            else
+              echo "❌ Invalid previous version format: $PREVIOUS_VERSION"
+              exit 1
+            fi
+
+            # Compare versions to determine release type
+            if [[ $CURRENT_MAJOR -gt $PREVIOUS_MAJOR ]]; then
+              RELEASE_TYPE="major"
+            elif [[ $CURRENT_MINOR -gt $PREVIOUS_MINOR ]]; then
+              RELEASE_TYPE="minor"
+            elif [[ $CURRENT_PATCH -gt $PREVIOUS_PATCH ]]; then
+              RELEASE_TYPE="patch"
+            else
+              echo "❌ Current version ($CURRENT_VERSION) is not greater than previous version ($PREVIOUS_VERSION)"
+              exit 1
+            fi
+
+            echo "📦 Version: $PREVIOUS_VERSION → $CURRENT_VERSION (Type: $RELEASE_TYPE)"
+          fi
+
+          echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+
+      - name: Get package name
+        id: package_name
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+
+      - name: Parse deployment config
+        id: parse_config
+        run: |
+          # Install yq for YAML parsing
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+          CONFIG_FILE=".github/cognigy-deployments.yml"
+          RELEASE_TYPE="${{ steps.version_info.outputs.release_type }}"
+
+          # Get all enabled deployments that match the release type
+          DEPLOYMENTS=$(yq eval ".deployments[] | select(.enabled == true) | select(.releaseTypes[] == \"$RELEASE_TYPE\")" "$CONFIG_FILE" -o=json -I=0)
+
+          if [[ -z "$DEPLOYMENTS" ]]; then
+            echo "No deployments configured for release type: $RELEASE_TYPE"
+            echo "count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Convert to matrix format
+          MATRIX=$(echo "$DEPLOYMENTS" | jq -s '.')
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "count=$(echo "$MATRIX" | jq 'length')" >> $GITHUB_OUTPUT
+
+          echo "🎯 Found $(echo "$MATRIX" | jq 'length') deployment(s) for release type: $RELEASE_TYPE"
+          echo "$MATRIX" | jq -r '.[] | "  - \(.name) (\(.environment))"'
+
+      - name: Deploy to Cognigy environments
+        if: steps.parse_config.outputs.count != '0'
+        env:
+          FAIL_FAST: ${{ vars.COGNIGY_FAIL_FAST || 'false' }}
+          VERSION: ${{ steps.version_info.outputs.version }}
+          PACKAGE_NAME: ${{ steps.package_name.outputs.name }}
+          COGNIGY_CSA_INT_API_KEY: ${{ secrets.COGNIGY_CSA_INT_API_KEY }}
+          COGNIGY_CSA_INT_URL: ${{ secrets.COGNIGY_CSA_INT_URL }}
+        run: |
+          DEPLOYMENTS='${{ steps.parse_config.outputs.matrix }}'
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/${PACKAGE_NAME}-${VERSION}.tar.gz"
+
+          echo "📦 Extension URL: $RELEASE_URL"
+          echo ""
+
+          FAILED_DEPLOYMENTS=()
+
+          # Deploy to each environment
+          echo "$DEPLOYMENTS" | jq -c '.[]' | while read -r deployment; do
+            NAME=$(echo "$deployment" | jq -r '.name')
+            ENV=$(echo "$deployment" | jq -r '.environment')
+            PROJECT_ID=$(echo "$deployment" | jq -r '.projectId')
+
+            echo "🚀 Deploying to: $NAME ($ENV)"
+
+            # Get secrets for this environment
+            API_KEY_VAR="COGNIGY_${ENV}_API_KEY"
+            API_URL_VAR="COGNIGY_${ENV}_URL"
+
+            API_KEY="${!API_KEY_VAR}"
+            API_URL="${!API_URL_VAR}"
+
+            if [[ -z "$API_KEY" ]]; then
+              echo "❌ Missing secret: $API_KEY_VAR"
+              FAILED_DEPLOYMENTS+=("$NAME: Missing API key")
+              [[ "$FAIL_FAST" == "true" ]] && exit 1
+              continue
+            fi
+
+            if [[ -z "$API_URL" ]]; then
+              echo "❌ Missing secret: $API_URL_VAR"
+              FAILED_DEPLOYMENTS+=("$NAME: Missing API URL")
+              [[ "$FAIL_FAST" == "true" ]] && exit 1
+              continue
+            fi
+
+            # Make API request
+            RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+              "${API_URL}/v2.0/extensions" \
+              -H "X-API-Key: ${API_KEY}" \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json" \
+              -d "{
+                \"projectId\": \"${PROJECT_ID}\",
+                \"url\": \"${RELEASE_URL}\",
+                \"name\": \"${PACKAGE_NAME}\"
+              }")
+
+            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+            BODY=$(echo "$RESPONSE" | head -n -1)
+
+            if [[ "$HTTP_CODE" == "202" ]]; then
+              TASK_ID=$(echo "$BODY" | jq -r '._id // "unknown"')
+              echo "✅ Deployment accepted (Task ID: $TASK_ID)"
+            else
+              echo "❌ Deployment failed (HTTP $HTTP_CODE)"
+              echo "Response: $BODY"
+              FAILED_DEPLOYMENTS+=("$NAME: HTTP $HTTP_CODE")
+              [[ "$FAIL_FAST" == "true" ]] && exit 1
+            fi
+
+            echo ""
+          done
+
+          # Report failures
+          if [[ ${#FAILED_DEPLOYMENTS[@]} -gt 0 ]]; then
+            echo "❌ Some deployments failed:"
+            printf '%s\n' "${FAILED_DEPLOYMENTS[@]}"
+            exit 1
+          fi
+
+          echo "✅ All deployments successful"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Adds automated deployment of extension releases to Cognigy projects.

### Changes

**Deployment Configuration** (`.github/cognigy-deployments.yml`)
- Define target Cognigy projects for deployments
- Filter deployments by release type (major/minor/patch)
- Enable/disable deployments per environment

**Release Workflow Updates** (`.github/workflows/release.yml`)
- Add deployment job that runs after release creation
- Compare versions to accurately determine release type
- Parse deployment config and filter by release type
- Deploy extension to configured Cognigy projects via API
- Configurable fail-fast behavior via `COGNIGY_FAIL_FAST` variable
- Add manual workflow trigger support

### Required Setup

**Repository Secrets:**
- `COGNIGY_CSA_INT_API_KEY` - API key for CSA_INT environment
- `COGNIGY_CSA_INT_URL` - Base URL (e.g., `https://api-trial.cognigy.ai`)

**Repository Variable (optional):**
- `COGNIGY_FAIL_FAST` - Set to `true` to stop on first deployment failure, `false` to continue (default: `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)