### PR TITLE
Fix deployment workflow multiline output

### DIFF
--- a/.github/cognigy-deployments.yml
+++ b/.github/cognigy-deployments.yml
@@ -18,3 +18,9 @@ deployments:
     projectId: "68cc9c59ae744c215e32ef67"
     releaseTypes: ["major", "minor", "patch"]
     enabled: true
+
+  - name: "SN - Master"
+    environment: "CSA_INT"
+    projectId: "68e5b35dd3fd946530d80988"
+    releaseTypes: ["major", "minor", "patch"]
+    enabled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,11 @@ jobs:
 
           # Convert to matrix format
           MATRIX=$(echo "$DEPLOYMENTS" | jq -s '.')
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          {
+            echo "matrix<<EOF"
+            echo "$MATRIX"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
           echo "count=$(echo "$MATRIX" | jq 'length')" >> $GITHUB_OUTPUT
 
           echo "🎯 Found $(echo "$MATRIX" | jq 'length') deployment(s) for release type: $RELEASE_TYPE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Hotfix for deployment workflow multiline JSON output error.

### Changes

- Fix multiline JSON output using heredoc format for GitHub Actions
- Add SN - Master deployment target (project ID: 68e5b35dd3fd946530d80988)
- Bump version to 1.0.5

### Fixes

Resolves error: `Invalid format '  {'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)