### PR TITLE
Remove SN - Master deployment target

### DIFF
--- a/.github/cognigy-deployments.yml
+++ b/.github/cognigy-deployments.yml
@@ -18,9 +18,3 @@ deployments:
     projectId: "68cc9c59ae744c215e32ef67"
     releaseTypes: ["major", "minor", "patch"]
     enabled: true
-
-  - name: "SN - Master"
-    environment: "CSA_INT"
-    projectId: "68e5b35dd3fd946530d80988"
-    releaseTypes: ["major", "minor", "patch"]
-    enabled: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Removes SN - Master deployment target from configuration.

### Changes

- Remove SN - Master from cognigy-deployments.yml
- Version bump to 1.0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)