### PR TITLE
Add logging to all Airtable nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {

--- a/src/nodes/getAll.ts
+++ b/src/nodes/getAll.ts
@@ -194,6 +194,20 @@ export const getAllNode = createNodeDescriptor({
 			contextKey
 		} = config as IGetAllParams["config"];
 
+		// Start logging
+		api.log("info", `Get All Records - Base: ${baseId}, Table: ${tableName}, Max: ${maxRecords}`);
+
+		if (filterByFormula) {
+			api.log("debug", `Filter: ${filterByFormula}`);
+		}
+
+		if (fields && fields.length > 0) {
+			api.log("debug", `Retrieving specific fields: ${fields.join(", ")}`);
+		}
+
+		if (sortField) {
+			api.log("debug", `Sort: ${sortField} (${sortDirection})`);
+		}
 
 		try {
 			const params: any = {
@@ -229,6 +243,8 @@ export const getAllNode = createNodeDescriptor({
 				total: response.data.records.length
 			};
 
+			api.log("info", `Retrieved ${response.data.records.length} records from table ${tableName}`);
+
 			if (storeLocation === "context") {
 				api.addToContext(contextKey, result, "simple");
 			} else {
@@ -237,6 +253,8 @@ export const getAllNode = createNodeDescriptor({
 			}
 
 		} catch (error: any) {
+			api.log("error", `Error retrieving records - Status: ${error.response?.status || "N/A"}, Message: ${error.response?.data?.error?.message || error.message}`);
+
 			const errorMessage = error.response?.data?.error?.message || error.message || "Unknown error occurred";
 			const errorResult = {
 				error: true,

--- a/src/nodes/getOneOrFail.ts
+++ b/src/nodes/getOneOrFail.ts
@@ -166,6 +166,9 @@ export const getOneOrFailNode = createNodeDescriptor({
 			contextKey
 		} = config as IGetOneOrFailParams["config"];
 
+		// Start logging
+		api.log("info", `Get One Record - Base: ${baseId}, Table: ${tableName}, Search: {${searchField}} = "${searchValue}"`);
+
 		try {
 			const params: any = {
 				filterByFormula: `{${searchField}} = "${searchValue}"`
@@ -188,8 +191,12 @@ export const getOneOrFailNode = createNodeDescriptor({
 
 			const records = response.data.records;
 
+			api.log("debug", `Found ${records.length} matching records`);
+
 			if (records.length === 0) {
 				// No records found - go to notFound path
+				api.log("info", "Routing to: notFound");
+
 				const result = {
 					found: false,
 					message: `No record found with ${searchField} = "${searchValue}"`
@@ -208,6 +215,8 @@ export const getOneOrFailNode = createNodeDescriptor({
 
 			} else if (records.length > 1) {
 				// Multiple records found - go to multipleFound path
+				api.log("info", `Routing to: multipleFound (${records.length} records)`);
+
 				const result = {
 					found: true,
 					multiple: true,
@@ -229,6 +238,8 @@ export const getOneOrFailNode = createNodeDescriptor({
 
 			} else {
 				// Exactly one record found - success path
+				api.log("info", `Routing to: success (Record ID: ${records[0].id})`);
+
 				const result = {
 					found: true,
 					multiple: false,
@@ -248,6 +259,9 @@ export const getOneOrFailNode = createNodeDescriptor({
 			}
 
 		} catch (error: any) {
+			api.log("error", `Error searching records - Status: ${error.response?.status || "N/A"}, Message: ${error.response?.data?.error?.message || error.message}`);
+			api.log("info", "Routing to: error");
+
 			const errorMessage = error.response?.data?.error?.message || error.message || "Unknown error occurred";
 			const errorResult = {
 				error: true,

--- a/src/nodes/insertRecord.ts
+++ b/src/nodes/insertRecord.ts
@@ -133,6 +133,12 @@ export const insertRecordNode = createNodeDescriptor({
 			contextKey
 		} = config as IInsertRecordParams["config"];
 
+		// Start logging
+		api.log("info", `Insert Record - Base: ${baseId}, Table: ${tableName}`);
+
+		const fieldCount = recordFields ? Object.keys(recordFields).length : 0;
+		api.log("debug", `Inserting record with ${fieldCount} fields`);
+
 		try {
 			const response = await axios.post(
 				`https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}`,
@@ -154,6 +160,8 @@ export const insertRecordNode = createNodeDescriptor({
 				createdTime: response.data.createdTime
 			};
 
+			api.log("info", `Record created - ID: ${response.data.id}`);
+
 			if (storeLocation === "context") {
 				api.addToContext(contextKey, result, "simple");
 			} else {
@@ -162,6 +170,8 @@ export const insertRecordNode = createNodeDescriptor({
 			}
 
 		} catch (error: any) {
+			api.log("error", `Error inserting record - Status: ${error.response?.status || "N/A"}, Message: ${error.response?.data?.error?.message || error.message}`);
+
 			const errorMessage = error.response?.data?.error?.message || error.message || "Unknown error occurred";
 			const errorResult = {
 				success: false,

--- a/src/nodes/upsertRecord.ts
+++ b/src/nodes/upsertRecord.ts
@@ -170,6 +170,9 @@ export const upsertRecordNode = createNodeDescriptor({
 			contextKey
 		} = config as IUpsertRecordParams["config"];
 
+		// Start logging
+		api.log("info", `Upsert Record - Base: ${baseId}, Table: ${tableName}, Search: {${searchField}} = "${searchValue}", Create if not found: ${createIfNotFound}`);
+
 		try {
 			// Step 1: Search for the record
 			const searchParams = {
@@ -189,11 +192,14 @@ export const upsertRecordNode = createNodeDescriptor({
 
 			const records = searchResponse.data.records;
 
+			api.log("debug", `Found ${records.length} matching records`);
+
 			// Step 2: Determine action based on search results
 			if (records.length === 0) {
 				// Record not found
 				if (createIfNotFound) {
 					// Create new record
+					api.log("info", "Creating new record");
 					const createResponse = await axios.post(
 						`https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}`,
 						{
@@ -213,6 +219,8 @@ export const upsertRecordNode = createNodeDescriptor({
 						record: createResponse.data
 					};
 
+					api.log("info", `Record created - ID: ${createResponse.data.id}`);
+
 					if (storeLocation === "context") {
 						api.addToContext(contextKey, result, "simple");
 					} else {
@@ -224,6 +232,7 @@ export const upsertRecordNode = createNodeDescriptor({
 					if (successChild) api.setNextNode(successChild.id);
 				} else {
 					// createIfNotFound is false, return not found
+					api.log("info", "Record not found and createIfNotFound is false");
 					const notFoundResult = {
 						success: false,
 						notFound: true,
@@ -246,6 +255,8 @@ export const upsertRecordNode = createNodeDescriptor({
 				// Record found - update it
 				const recordId = records[0].id;
 
+				api.log("info", `Updating existing record - ID: ${recordId}`);
+
 				const updateResponse = await axios.patch(
 					`https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}/${recordId}`,
 					{
@@ -265,6 +276,8 @@ export const upsertRecordNode = createNodeDescriptor({
 					record: updateResponse.data
 				};
 
+				api.log("info", `Record updated - ID: ${updateResponse.data.id}`);
+
 				if (storeLocation === "context") {
 					api.addToContext(contextKey, result, "simple");
 				} else {
@@ -276,6 +289,7 @@ export const upsertRecordNode = createNodeDescriptor({
 				if (successChild) api.setNextNode(successChild.id);
 			} else {
 				// Multiple records found
+				api.log("error", `Error: Multiple records found (${records.length}), cannot upsert`);
 				const errorResult = {
 					success: false,
 					error: true,
@@ -297,6 +311,8 @@ export const upsertRecordNode = createNodeDescriptor({
 			}
 
 		} catch (error: any) {
+			api.log("error", `Error during upsert - Status: ${error.response?.status || "N/A"}, Message: ${error.response?.data?.error?.message || error.message}`);
+
 			const errorMessage = error.response?.data?.error?.message || error.message || "Unknown error occurred";
 			const errorResult = {
 				success: false,


### PR DESCRIPTION
## Summary

Adds consistent, concise logging to all four Airtable nodes to improve troubleshooting and debugging capabilities.

## Changes

### getAll.ts
- Base ID, Table Name, Max Records on start
- Query parameters (filter, fields, sort) when used
- Record count on success
- Error status and message on failure

### getOneOrFail.ts
- Search parameters on start
- Number of matching records found
- Routing decisions (success/notFound/multipleFound/error)
- Record ID on success
- Error status and message on failure

### insertRecord.ts
- Base ID, Table Name on start
- Number of fields being inserted
- Created record ID on success
- Error status and message on failure

### upsertRecord.ts
- Search parameters and createIfNotFound flag on start
- Number of matching records found
- Action taken (creating/updating/not found)
- Record ID with operation indicator on success
- Multiple found errors and HTTP errors with details

## Logging Principles

- Uses appropriate log levels: `info` for flow, `debug` for details, `error` for failures
- Consistent format across all nodes
- Includes relevant identifiers without verbose data dumps
- Helps trace execution flow and diagnose issues

## Version

Bumped to v1.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)