### PR TITLE
Add Get Table Schema node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@cognigy/extension-tools": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Airtable Extension for Cognigy.AI to query and retrieve records from Airtable bases",
   "main": "build/module.js",
   "scripts": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,7 @@ import { getAllNode } from "./nodes/getAll";
 import { getOneOrFailNode, successNode, notFoundNode, multipleFoundNode, errorNode } from "./nodes/getOneOrFail";
 import { insertRecordNode } from "./nodes/insertRecord";
 import { upsertRecordNode, upsertSuccessNode, upsertNotFoundNode, upsertErrorNode } from "./nodes/upsertRecord";
+import { getTableSchemaNode } from "./nodes/getTableSchema";
 
 /* import all connections */
 import { airtableConnection } from "./connections/airtableConnection";
@@ -15,6 +16,7 @@ export default createExtension({
 		getOneOrFailNode,
 		insertRecordNode,
 		upsertRecordNode,
+		getTableSchemaNode,
 		successNode,
 		notFoundNode,
 		multipleFoundNode,

--- a/src/nodes/getTableSchema.ts
+++ b/src/nodes/getTableSchema.ts
@@ -7,7 +7,7 @@ export interface IGetTableSchemaParams extends INodeFunctionBaseParams {
 			accessToken: string;
 		};
 		baseId: string;
-		tableName: string;
+		tableId: string;
 		storeLocation: string;
 		inputKey: string;
 		contextKey: string;
@@ -41,11 +41,13 @@ export const getTableSchemaNode = createNodeDescriptor({
 			}
 		},
 		{
-			key: "tableName",
-			label: "Table Name (Optional)",
+			key: "tableId",
+			label: "Table ID",
 			type: "cognigyText",
-			description: "Specific table name to filter by (leave empty to get all tables)",
-			defaultValue: ""
+			description: "The Airtable table ID (e.g., tbl...)",
+			params: {
+				required: true
+			}
 		},
 		{
 			key: "storeLocation",
@@ -102,7 +104,7 @@ export const getTableSchemaNode = createNodeDescriptor({
 	form: [
 		{ type: "field", key: "connection" },
 		{ type: "field", key: "baseId" },
-		{ type: "field", key: "tableName" },
+		{ type: "field", key: "tableId" },
 		{ type: "section", key: "storageOption" }
 	],
 	appearance: {
@@ -113,14 +115,14 @@ export const getTableSchemaNode = createNodeDescriptor({
 		const {
 			connection,
 			baseId,
-			tableName,
+			tableId,
 			storeLocation,
 			inputKey,
 			contextKey
 		} = config as IGetTableSchemaParams["config"];
 
 		// Start logging
-		api.log("info", `Get Table Schema - Base: ${baseId}${tableName ? `, Table: ${tableName}` : " (all tables)"}`);
+		api.log("info", `Get Table Schema - Base: ${baseId}, Table ID: ${tableId}`);
 
 		try {
 			const response = await axios.get(
@@ -133,37 +135,48 @@ export const getTableSchemaNode = createNodeDescriptor({
 				}
 			);
 
-			let tables = response.data.tables;
+			// Filter by table ID
+			const tables = response.data.tables.filter((t: any) => t.id === tableId);
 
-			// Filter by table name if specified
-			if (tableName) {
-				tables = tables.filter((t: any) => t.name === tableName);
-				api.log("debug", `Filtered to ${tables.length} table(s) matching "${tableName}"`);
+			if (tables.length === 0) {
+				api.log("error", `Table with ID "${tableId}" not found in base ${baseId}`);
+				const notFoundResult = {
+					error: true,
+					message: `Table with ID "${tableId}" not found`,
+					status: 404
+				};
+
+				if (storeLocation === "context") {
+					api.addToContext(contextKey, notFoundResult, "simple");
+				} else {
+					// @ts-ignore
+					api.addToInput(inputKey, notFoundResult);
+				}
+				return;
 			}
 
-			api.log("info", `Retrieved schema for ${tables.length} table(s)`);
+			api.log("info", `Retrieved schema for table "${tables[0].name}" with ${tables[0].fields?.length || 0} fields`);
 
 			// Build result with useful information
 			const result = {
-				tables: tables.map((table: any) => ({
-					id: table.id,
-					name: table.name,
-					description: table.description || null,
-					fieldCount: table.fields?.length || 0,
-					fields: table.fields?.map((field: any) => ({
+				table: {
+					id: tables[0].id,
+					name: tables[0].name,
+					description: tables[0].description || null,
+					fieldCount: tables[0].fields?.length || 0,
+					fields: tables[0].fields?.map((field: any) => ({
 						id: field.id,
 						name: field.name,
 						type: field.type,
 						description: field.description || null,
 						options: field.options || null
 					})) || []
-				})),
-				total: tables.length
+				}
 			};
 
-			// Log field counts for each table
-			tables.forEach((table: any) => {
-				api.log("debug", `Table "${table.name}": ${table.fields?.length || 0} fields`);
+			// Log field details
+			tables[0].fields?.forEach((field: any) => {
+				api.log("debug", `  - ${field.name} (${field.type})`);
 			});
 
 			if (storeLocation === "context") {

--- a/src/nodes/getTableSchema.ts
+++ b/src/nodes/getTableSchema.ts
@@ -1,0 +1,194 @@
+import { createNodeDescriptor, INodeFunctionBaseParams } from "@cognigy/extension-tools";
+import axios from "axios";
+
+export interface IGetTableSchemaParams extends INodeFunctionBaseParams {
+	config: {
+		connection: {
+			accessToken: string;
+		};
+		baseId: string;
+		tableName: string;
+		storeLocation: string;
+		inputKey: string;
+		contextKey: string;
+	};
+}
+
+export const getTableSchemaNode = createNodeDescriptor({
+	type: "airtable-get-table-schema",
+	defaultLabel: "Get Table Schema",
+	preview: {
+		key: "baseId",
+		type: "text"
+	},
+	fields: [
+		{
+			key: "connection",
+			label: "Airtable Connection",
+			type: "connection",
+			params: {
+				connectionType: "airtable-token",
+				required: true
+			}
+		},
+		{
+			key: "baseId",
+			label: "Base ID",
+			type: "cognigyText",
+			description: "The Airtable base ID (found in the URL: app...)",
+			params: {
+				required: true
+			}
+		},
+		{
+			key: "tableName",
+			label: "Table Name (Optional)",
+			type: "cognigyText",
+			description: "Specific table name to filter by (leave empty to get all tables)",
+			defaultValue: ""
+		},
+		{
+			key: "storeLocation",
+			type: "select",
+			label: "Where to store the result",
+			params: {
+				options: [
+					{
+						label: "Input",
+						value: "input"
+					},
+					{
+						label: "Context",
+						value: "context"
+					}
+				],
+				required: true
+			},
+			defaultValue: "context"
+		},
+		{
+			key: "inputKey",
+			type: "cognigyText",
+			label: "Input Key to store Result",
+			defaultValue: "airtableSchema",
+			condition: {
+				key: "storeLocation",
+				value: "input"
+			}
+		},
+		{
+			key: "contextKey",
+			type: "cognigyText",
+			label: "Context Key to store Result",
+			defaultValue: "airtableSchema",
+			condition: {
+				key: "storeLocation",
+				value: "context"
+			}
+		}
+	],
+	sections: [
+		{
+			key: "storageOption",
+			label: "Storage Option",
+			defaultCollapsed: true,
+			fields: [
+				"storeLocation",
+				"inputKey",
+				"contextKey"
+			]
+		}
+	],
+	form: [
+		{ type: "field", key: "connection" },
+		{ type: "field", key: "baseId" },
+		{ type: "field", key: "tableName" },
+		{ type: "section", key: "storageOption" }
+	],
+	appearance: {
+		color: "#ffb100"
+	},
+	function: async ({ cognigy, config }: INodeFunctionBaseParams) => {
+		const { api } = cognigy;
+		const {
+			connection,
+			baseId,
+			tableName,
+			storeLocation,
+			inputKey,
+			contextKey
+		} = config as IGetTableSchemaParams["config"];
+
+		// Start logging
+		api.log("info", `Get Table Schema - Base: ${baseId}${tableName ? `, Table: ${tableName}` : " (all tables)"}`);
+
+		try {
+			const response = await axios.get(
+				`https://api.airtable.com/v0/meta/bases/${baseId}/tables`,
+				{
+					headers: {
+						Authorization: `Bearer ${connection.accessToken}`,
+						"Content-Type": "application/json"
+					}
+				}
+			);
+
+			let tables = response.data.tables;
+
+			// Filter by table name if specified
+			if (tableName) {
+				tables = tables.filter((t: any) => t.name === tableName);
+				api.log("debug", `Filtered to ${tables.length} table(s) matching "${tableName}"`);
+			}
+
+			api.log("info", `Retrieved schema for ${tables.length} table(s)`);
+
+			// Build result with useful information
+			const result = {
+				tables: tables.map((table: any) => ({
+					id: table.id,
+					name: table.name,
+					description: table.description || null,
+					fieldCount: table.fields?.length || 0,
+					fields: table.fields?.map((field: any) => ({
+						id: field.id,
+						name: field.name,
+						type: field.type,
+						description: field.description || null,
+						options: field.options || null
+					})) || []
+				})),
+				total: tables.length
+			};
+
+			// Log field counts for each table
+			tables.forEach((table: any) => {
+				api.log("debug", `Table "${table.name}": ${table.fields?.length || 0} fields`);
+			});
+
+			if (storeLocation === "context") {
+				api.addToContext(contextKey, result, "simple");
+			} else {
+				// @ts-ignore
+				api.addToInput(inputKey, result);
+			}
+
+		} catch (error: any) {
+			api.log("error", `Error retrieving table schema - Status: ${error.response?.status || "N/A"}, Message: ${error.response?.data?.error?.message || error.message}`);
+
+			const errorMessage = error.response?.data?.error?.message || error.message || "Unknown error occurred";
+			const errorResult = {
+				error: true,
+				message: errorMessage,
+				status: error.response?.status
+			};
+
+			if (storeLocation === "context") {
+				api.addToContext(contextKey, errorResult, "simple");
+			} else {
+				// @ts-ignore
+				api.addToInput(inputKey, errorResult);
+			}
+		}
+	}
+});


### PR DESCRIPTION
## Summary
- Adds new node to retrieve table and field schema from Airtable bases
- Uses Airtable's `GET /v0/meta/bases/{baseId}/tables` endpoint
- Supports optional filtering by table name
- Returns complete schema information including field types, descriptions, and options

## Test plan
- [ ] Build successful (transpile, lint, zip)
- [ ] Test with real Airtable base to retrieve all tables
- [ ] Test with specific table name filter
- [ ] Verify error handling for invalid base IDs
- [ ] Verify response structure matches expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)